### PR TITLE
Adjust regular expression to enable negative decimals input

### DIFF
--- a/lib/src/input_qty.dart
+++ b/lib/src/input_qty.dart
@@ -481,7 +481,7 @@ class _InputQtyState extends State<InputQty> {
         enabled: widget.qtyFormProps.enabled,
         showCursor: widget.qtyFormProps.showCursor,
         inputFormatters: [
-          FilteringTextInputFormatter.allow(RegExp(r'^\d*\.?\-?\d*'))
+          FilteringTextInputFormatter.allow(RegExp(r'^-?\d*\.?\d*'))
         ],
         onChanged: (String strVal) {
           if (widget._outputType == _OutputType.integer &&


### PR DESCRIPTION
# Pull Request Details

- Adjust the regular expression in `input-quantity/lib/src/input_qty.dart` at line 484 to enable negative decimals input.
- Link to associated issues: #64.